### PR TITLE
Fix PUT requests

### DIFF
--- a/doi_site/urls.py
+++ b/doi_site/urls.py
@@ -5,7 +5,7 @@ from django.contrib import admin
 
 from datasets.views import Mint
 from doi_site.views import DoiList, Domains, HomeView, Notes, Login, Logout
-from mds.views import DoiView, DoiDetail, MetadataView, MediaView
+from mds.views import DoiView, MetadataView, MediaView
 
 
 # pylint: disable=invalid-name
@@ -22,7 +22,7 @@ urlpatterns = [
 
     # MDS
     re_path(r"^doi$", DoiView.as_view(), name="doi_view"),
-    re_path(r"^doi/", DoiDetail.as_view(), name="doi_detail"),
+    re_path(r"^doi/", DoiView.as_view(), name="doi_view"),
     re_path(r"^metadata$", MetadataView.as_view(), name="metadata_view"),
     re_path(r"^metadata/", MetadataView.as_view(), name="metadata_view"),
     re_path(r"^media/", MediaView.as_view(), name="media_view"),

--- a/mds/http/post.py
+++ b/mds/http/post.py
@@ -58,10 +58,21 @@ def post_doi(request):
             "Bad Request - wrong prefix, doi should start " "with %s" % DOI_PREFIX, 400
         )
 
+    try:
+        # The URL can contain the DOI - check that it matches
+        url_doi = request.get_full_path().split("doi/", 1)[1]
+        if len(url_doi) > 0 and url_doi != _doi:
+            return get_response(
+                "Bad Request - DOI in URL does not match DOI in request body\n", 400
+            )
+    except IndexError:
+        # There is no DOI in the URL, which is fine
+        pass
+
     if not is_authorized(request, doi_suffix):
         return get_response("Unauthorized - insufficient privileges", 403)
 
-    url = urljoin(DATACITE_URL, request.get_full_path())
+    url = urljoin(DATACITE_URL, "/doi")
     return _post(url, request.body, _get_content_type_header(request))
 
 

--- a/mds/http/post.py
+++ b/mds/http/post.py
@@ -31,7 +31,7 @@ import xml.etree.ElementTree as ET
 LOGGING = logging.getLogger(__name__)
 
 
-def post_doi(request):
+def post_doi(request, method="POST"):
     """
     Post the DOI.
 
@@ -72,8 +72,8 @@ def post_doi(request):
     if not is_authorized(request, doi_suffix):
         return get_response("Unauthorized - insufficient privileges", 403)
 
-    url = urljoin(DATACITE_URL, "/doi")
-    return _post(url, request.body, _get_content_type_header(request))
+    url = urljoin(DATACITE_URL, request.get_full_path())
+    return _post(url, request.body, _get_content_type_header(request), method=method)
 
 
 def post_media(request):
@@ -106,7 +106,7 @@ def post_media(request):
     return _post(url, request.body, _get_content_type_header(request))
 
 
-def post_metadata(request):
+def post_metadata(request, method="POST"):
     """
     Post the metadata.
 
@@ -148,10 +148,10 @@ def post_metadata(request):
         return get_response("Unauthorized - insufficient privileges", 403)
 
     url = urljoin(DATACITE_URL, request.get_full_path())
-    return _post(url, request.body, _get_content_type_header(request))
+    return _post(url, request.body, _get_content_type_header(request), method=method)
 
 
-def _post(url, body, headers):
+def _post(url, body, headers, method="POST"):
     """
     Send a post request to DataCite.
 
@@ -180,7 +180,7 @@ def _post(url, body, headers):
     # UTF-8 encoded.
     url_encode = url.encode("utf-8").decode()
 
-    req = urllib.request.Request(url_encode, data=body, headers=headers)
+    req = urllib.request.Request(url_encode, data=body, headers=headers, method=method)
     try:
         response = opener.open(req)
     except urllib.error.HTTPError as ex:

--- a/mds/views.py
+++ b/mds/views.py
@@ -64,7 +64,7 @@ class MetadataView(View):
         """
         PUT does the same as POST.
         """
-        return post_metadata(request)
+        return post_metadata(request, method="PUT")
 
 
 class DoiView(View):
@@ -111,7 +111,7 @@ class DoiView(View):
         PUT does the same as POST.
 
         """
-        return post_doi(request)
+        return post_doi(request, method="PUT")
 
 
 

--- a/mds/views.py
+++ b/mds/views.py
@@ -69,7 +69,7 @@ class MetadataView(View):
 
 class DoiView(View):
     """
-    Handle post requests for DOIs and get and head requests for all DOIs.
+    Handle head, get, post and put requests for DOIs.
 
     """
 
@@ -80,8 +80,9 @@ class DoiView(View):
 
     def get(self, request):
         """
-        This request returns a list of all DOIs for the requesting datacentre.
-        There is no guaranteed order.
+        This request returns a URL associated with a given DOI, or a list of
+        all DOIs for the requesting datacentre if no DOI is given (there is no
+        guaranteed order).
 
         """
         url = urljoin(DATACITE_URL, request.get_full_path())
@@ -89,7 +90,7 @@ class DoiView(View):
 
     def head(self, request):
         """
-        Request a list of all DOIs for the requesting datacentre.
+        HEAD does the same as GET.
 
         """
         url = urljoin(DATACITE_URL, request.get_full_path())
@@ -105,32 +106,13 @@ class DoiView(View):
         """
         return post_doi(request)
 
-
-class DoiDetail(View):
-    """
-    Handle get and head requests for an individual DOIs.
-
-    """
-
-    @method_decorator(logged_in_or_basicauth())
-    def dispatch(self, request, *args, **kwargs):
-        return super().dispatch(request, *args, **kwargs)
-
-    def get(self, request):
+    def put(self, request):
         """
-        This request returns an URL associated with a given DOI.
+        PUT does the same as POST.
 
         """
-        url = urljoin(DATACITE_URL, request.get_full_path())
-        return _get(request.method, url, get_accept_header(request))
+        return post_doi(request)
 
-    def head(self, request):
-        """
-        Request an URL associated with a given DOI.
-
-        """
-        url = urljoin(DATACITE_URL, request.get_full_path())
-        return _get(request.method, url, get_accept_header(request))
 
 
 class MediaView(View):


### PR DESCRIPTION
Handle PUT requests to `/doi`
Handle POST requests to `/doi` where a DOI is included in the URL
Proxy PUT requests to `/metadata` instead of rewriting them as POST requests
